### PR TITLE
New profile for "The Witcher"

### DIFF
--- a/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
+++ b/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
@@ -494,10 +494,6 @@
                         <code>0x1000033</code>
                         <mode>keyboard</mode>
                     </slot>
-                    <slot>
-                        <code>2</code>
-                        <mode>mousebutton</mode>
-                    </slot>
                 </slots>
             </button>
             <button index="9">

--- a/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
+++ b/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
@@ -366,7 +366,7 @@
                     <actionname>Strong Style</actionname>
                     <slots>
                         <slot>
-                            <code>0x59</code>
+                            <code>0x5a</code>
                             <mode>keyboard</mode>
                         </slot>
                     </slots>

--- a/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
+++ b/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
@@ -476,11 +476,27 @@
                 </slots>
             </button>
             <button index="8">
-                <actionname>System Menu / Skip Intro Videos</actionname>
+                <actionname>System Menu / Skip Intro Videos / Quit (Hold .5s)</actionname>
                 <slots>
                     <slot>
                         <code>0x1000000</code>
                         <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>500</code>
+                        <mode>release</mode>
+                    </slot>
+                    <slot>
+                        <code>0x1000023</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>0x1000033</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>2</code>
+                        <mode>mousebutton</mode>
                     </slot>
                 </slots>
             </button>

--- a/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
+++ b/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gamecontroller configversion="9" appversion="2.4">
+<gamecontroller configversion="19" appversion="2.23">
     <!--The SDL name for a joystick is included for informational purposes only.-->
-    <sdlname>X360 Controller</sdlname>
+    <sdlname>XInput Controller</sdlname>
+    <!--The GUID for a joystick is included for informational purposes only.-->
+    <guid>78696e70757401000000000000000000</guid>
+    <profilename>The Witcher</profilename>
     <names/>
     <sets>
         <set index="1">
             <stick index="1">
-                <deadZone>8000</deadZone>
-                <maxZone>32000</maxZone>
-                <diagonalRange>45</diagonalRange>
+                <stickbutton index="1">
+                    <actionname>Move Forward</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x57</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
                 <stickbutton index="3">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
+                    <actionname>Strafe Right</actionname>
                     <slots>
                         <slot>
                             <code>0x44</code>
@@ -28,16 +28,7 @@
                     </slots>
                 </stickbutton>
                 <stickbutton index="5">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
+                    <actionname>Move Backward</actionname>
                     <slots>
                         <slot>
                             <code>0x53</code>
@@ -46,16 +37,7 @@
                     </slots>
                 </stickbutton>
                 <stickbutton index="7">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
+                    <actionname>Strafe Left</actionname>
                     <slots>
                         <slot>
                             <code>0x41</code>
@@ -63,94 +45,12 @@
                         </slot>
                     </slots>
                 </stickbutton>
-                <stickbutton index="1">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
-                    <slots>
-                        <slot>
-                            <code>0x57</code>
-                            <mode>keyboard</mode>
-                        </slot>
-                    </slots>
-                </stickbutton>
             </stick>
             <stick index="2">
-                <deadZone>8000</deadZone>
-                <maxZone>32000</maxZone>
-                <diagonalRange>45</diagonalRange>
-                <stickbutton index="3">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
-                    <slots>
-                        <slot>
-                            <code>4</code>
-                            <mode>mousemovement</mode>
-                        </slot>
-                    </slots>
-                </stickbutton>
-                <stickbutton index="5">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
-                    <slots>
-                        <slot>
-                            <code>2</code>
-                            <mode>mousemovement</mode>
-                        </slot>
-                    </slots>
-                </stickbutton>
-                <stickbutton index="7">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
-                    <slots>
-                        <slot>
-                            <code>3</code>
-                            <mode>mousemovement</mode>
-                        </slot>
-                    </slots>
-                </stickbutton>
+                <diagonalRange>90</diagonalRange>
                 <stickbutton index="1">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
+                    <mousespeedx>100</mousespeedx>
+                    <mousespeedy>100</mousespeedy>
                     <slots>
                         <slot>
                             <code>1</code>
@@ -158,55 +58,57 @@
                         </slot>
                     </slots>
                 </stickbutton>
+                <stickbutton index="2">
+                    <mousespeedx>100</mousespeedx>
+                    <mousespeedy>100</mousespeedy>
+                </stickbutton>
+                <stickbutton index="3">
+                    <mousespeedx>100</mousespeedx>
+                    <mousespeedy>100</mousespeedy>
+                    <slots>
+                        <slot>
+                            <code>4</code>
+                            <mode>mousemovement</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="4">
+                    <mousespeedx>100</mousespeedx>
+                    <mousespeedy>100</mousespeedy>
+                </stickbutton>
+                <stickbutton index="5">
+                    <mousespeedx>100</mousespeedx>
+                    <mousespeedy>100</mousespeedy>
+                    <slots>
+                        <slot>
+                            <code>2</code>
+                            <mode>mousemovement</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="6">
+                    <mousespeedx>100</mousespeedx>
+                    <mousespeedy>100</mousespeedy>
+                </stickbutton>
+                <stickbutton index="7">
+                    <mousespeedx>100</mousespeedx>
+                    <mousespeedy>100</mousespeedy>
+                    <slots>
+                        <slot>
+                            <code>3</code>
+                            <mode>mousemovement</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="8">
+                    <mousespeedx>100</mousespeedx>
+                    <mousespeedy>100</mousespeedy>
+                </stickbutton>
             </stick>
             <dpad index="1">
-                <dpadbutton index="4">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
-                    <slots>
-                        <slot>
-                            <code>0x33</code>
-                            <mode>keyboard</mode>
-                        </slot>
-                    </slots>
-                </dpadbutton>
-                <dpadbutton index="8">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
-                    <slots>
-                        <slot>
-                            <code>0x34</code>
-                            <mode>keyboard</mode>
-                        </slot>
-                    </slots>
-                </dpadbutton>
+                <mode>four-way</mode>
                 <dpadbutton index="1">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
+                    <actionname>Sign: Aard</actionname>
                     <slots>
                         <slot>
                             <code>0x31</code>
@@ -215,16 +117,7 @@
                     </slots>
                 </dpadbutton>
                 <dpadbutton index="2">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
+                    <actionname>Sign: Quen</actionname>
                     <slots>
                         <slot>
                             <code>0x32</code>
@@ -232,100 +125,69 @@
                         </slot>
                     </slots>
                 </dpadbutton>
-            </dpad>
-            <trigger index="1">
-                <deadZone>2000</deadZone>
-                <maxZone>32000</maxZone>
-                <throttle>positivehalf</throttle>
-                <triggerbutton index="2">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
+                <dpadbutton index="4">
+                    <actionname>Sign: Yrden</actionname>
                     <slots>
                         <slot>
-                            <code>0x49</code>
+                            <code>0x33</code>
                             <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </dpadbutton>
+                <dpadbutton index="8">
+                    <actionname>Sign: Igni</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x34</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </dpadbutton>
+            </dpad>
+            <trigger index="1">
+                <deadZone>6000</deadZone>
+                <throttle>positivehalf</throttle>
+                <triggerbutton index="2">
+                    <slots>
+                        <slot>
+                            <code>3</code>
+                            <mode>mousebutton</mode>
                         </slot>
                     </slots>
                 </triggerbutton>
             </trigger>
             <trigger index="2">
-                <deadZone>2000</deadZone>
-                <maxZone>32000</maxZone>
+                <deadZone>6000</deadZone>
                 <throttle>positivehalf</throttle>
                 <triggerbutton index="2">
-                    <toggle>false</toggle>
-                    <turbointerval>0</turbointerval>
-                    <useturbo>false</useturbo>
-                    <mousespeedx>50</mousespeedx>
-                    <mousespeedy>50</mousespeedy>
-                    <mousemode>cursor</mousemode>
-                    <mouseacceleration>precision</mouseacceleration>
-                    <mousesmoothing>false</mousesmoothing>
-                    <wheelspeedx>20</wheelspeedx>
-                    <wheelspeedy>20</wheelspeedy>
                     <slots>
                         <slot>
-                            <code>0x4d</code>
-                            <mode>keyboard</mode>
+                            <code>1</code>
+                            <mode>mousebutton</mode>
                         </slot>
                     </slots>
                 </triggerbutton>
             </trigger>
             <button index="1">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
+                <actionname>Sign: Axii</actionname>
                 <slots>
                     <slot>
-                        <code>1</code>
-                        <mode>mousebutton</mode>
+                        <code>0x35</code>
+                        <mode>keyboard</mode>
                     </slot>
                 </slots>
             </button>
             <button index="2">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
+                <actionname>Non-Combat Mode</actionname>
                 <slots>
                     <slot>
-                        <code>3</code>
-                        <mode>mousebutton</mode>
+                        <code>0x1000001</code>
+                        <mode>keyboard</mode>
                     </slot>
                 </slots>
             </button>
             <button index="3">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
+                <actionname>Silver Sword</actionname>
                 <slots>
                     <slot>
                         <code>0x45</code>
@@ -334,16 +196,7 @@
                 </slots>
             </button>
             <button index="4">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
+                <actionname>Steel Sword</actionname>
                 <slots>
                     <slot>
                         <code>0x51</code>
@@ -352,52 +205,16 @@
                 </slots>
             </button>
             <button index="5">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
+                <actionname>Journal</actionname>
                 <slots>
                     <slot>
-                        <code>0x35</code>
+                        <code>0x4a</code>
                         <mode>keyboard</mode>
                     </slot>
                 </slots>
             </button>
             <button index="6">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
-                <slots>
-                    <slot>
-                        <code>0x48</code>
-                        <mode>keyboard</mode>
-                    </slot>
-                </slots>
-            </button>
-            <button index="7">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
+                <actionname>Pause Game / Steam Overlay</actionname>
                 <slots>
                     <slot>
                         <code>0x20</code>
@@ -405,38 +222,318 @@
                     </slot>
                 </slots>
             </button>
-            <button index="10">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
+            <button index="7">
+                <actionname>Map</actionname>
                 <slots>
                     <slot>
-                        <code>0x1000001</code>
+                        <code>0x4d</code>
                         <mode>keyboard</mode>
                     </slot>
                 </slots>
             </button>
-            <button index="11">
-                <toggle>false</toggle>
-                <turbointerval>0</turbointerval>
-                <useturbo>false</useturbo>
-                <mousespeedx>50</mousespeedx>
-                <mousespeedy>50</mousespeedy>
-                <mousemode>cursor</mousemode>
-                <mouseacceleration>precision</mouseacceleration>
-                <mousesmoothing>false</mousesmoothing>
-                <wheelspeedx>20</wheelspeedx>
-                <wheelspeedy>20</wheelspeedy>
+            <button index="8">
+                <actionname>Quick Slot 2</actionname>
                 <slots>
                     <slot>
-                        <code>0x4c</code>
+                        <code>0x37</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="9">
+                <actionname>Quick Slot 3</actionname>
+                <slots>
+                    <slot>
+                        <code>0x38</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="10">
+                <setselect>2</setselect>
+                <setselectcondition>while-held</setselectcondition>
+            </button>
+            <button index="11">
+                <actionname>Quick Slot 1</actionname>
+                <slots>
+                    <slot>
+                        <code>0x36</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+        </set>
+        <set index="2">
+            <stick index="1">
+                <stickbutton index="1">
+                    <actionname>Move Forward</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x57</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="3">
+                    <actionname>Strafe Right</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x44</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="5">
+                    <actionname>Move Backward</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x53</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="7">
+                    <actionname>Strafe Left</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x41</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+            </stick>
+            <stick index="2">
+                <diagonalRange>90</diagonalRange>
+                <stickbutton index="1">
+                    <mousespeedx>150</mousespeedx>
+                    <mousespeedy>150</mousespeedy>
+                    <slots>
+                        <slot>
+                            <code>1</code>
+                            <mode>mousemovement</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="2">
+                    <mousespeedx>150</mousespeedx>
+                    <mousespeedy>150</mousespeedy>
+                </stickbutton>
+                <stickbutton index="3">
+                    <mousespeedx>150</mousespeedx>
+                    <mousespeedy>150</mousespeedy>
+                    <slots>
+                        <slot>
+                            <code>4</code>
+                            <mode>mousemovement</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="4">
+                    <mousespeedx>150</mousespeedx>
+                    <mousespeedy>150</mousespeedy>
+                </stickbutton>
+                <stickbutton index="5">
+                    <mousespeedx>150</mousespeedx>
+                    <mousespeedy>150</mousespeedy>
+                    <slots>
+                        <slot>
+                            <code>2</code>
+                            <mode>mousemovement</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="6">
+                    <mousespeedx>150</mousespeedx>
+                    <mousespeedy>150</mousespeedy>
+                </stickbutton>
+                <stickbutton index="7">
+                    <mousespeedx>150</mousespeedx>
+                    <mousespeedy>150</mousespeedy>
+                    <slots>
+                        <slot>
+                            <code>3</code>
+                            <mode>mousemovement</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="8">
+                    <mousespeedx>150</mousespeedx>
+                    <mousespeedy>150</mousespeedy>
+                </stickbutton>
+            </stick>
+            <dpad index="1">
+                <dpadbutton index="1">
+                    <actionname>Strong Style</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x59</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </dpadbutton>
+                <dpadbutton index="2">
+                    <actionname>Fast Style</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x58</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </dpadbutton>
+                <dpadbutton index="4">
+                    <actionname>Group Style</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x43</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </dpadbutton>
+                <dpadbutton index="8">
+                    <actionname>Alchemy</actionname>
+                    <slots>
+                        <slot>
+                            <code>0x4c</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </dpadbutton>
+            </dpad>
+            <trigger index="1">
+                <throttle>positivehalf</throttle>
+                <triggerbutton index="2">
+                    <slots>
+                        <slot>
+                            <code>0x1000016</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </triggerbutton>
+            </trigger>
+            <trigger index="2">
+                <throttle>positivehalf</throttle>
+                <triggerbutton index="2">
+                    <slots>
+                        <slot>
+                            <code>0x1000017</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </triggerbutton>
+            </trigger>
+            <button index="1">
+                <actionname>Quick Save</actionname>
+                <slots>
+                    <slot>
+                        <code>0x1000034</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="2">
+                <actionname>Quick Load</actionname>
+                <slots>
+                    <slot>
+                        <code>0x1000038</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="3">
+                <actionname>Extra Weapon 3</actionname>
+                <slots>
+                    <slot>
+                        <code>0x55</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="4">
+                <actionname>Extra Weapon 1</actionname>
+                <slots>
+                    <slot>
+                        <code>0x52</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="5">
+                <actionname>Inventory</actionname>
+                <slots>
+                    <slot>
+                        <code>0x49</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="7">
+                <actionname>Hero</actionname>
+                <slots>
+                    <slot>
+                        <code>0x48</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="8">
+                <actionname>System Menu / Skip Intro Videos</actionname>
+                <slots>
+                    <slot>
+                        <code>0x1000000</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="9">
+                <actionname>Toggle Visible Object Names</actionname>
+                <slots>
+                    <slot>
+                        <code>0x1000023</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="10">
+                <setselect>1</setselect>
+                <setselectcondition>while-held</setselectcondition>
+            </button>
+            <button index="11">
+                <actionname>Camera</actionname>
+                <slots>
+                    <slot>
+                        <code>0x1000030</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>1</code>
+                        <mode>cycle</mode>
+                    </slot>
+                    <slot>
+                        <code>0x1000031</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>1</code>
+                        <mode>cycle</mode>
+                    </slot>
+                    <slot>
+                        <code>0x1000032</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>1</code>
+                        <mode>cycle</mode>
+                    </slot>
+                    <slot>
+                        <code>0x47</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>1</code>
+                        <mode>cycle</mode>
+                    </slot>
+                    <slot>
+                        <code>0x46</code>
                         <mode>keyboard</mode>
                     </slot>
                 </slots>

--- a/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
+++ b/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
@@ -484,7 +484,7 @@
                     </slot>
                     <slot>
                         <code>500</code>
-                        <mode>release</mode>
+                        <mode>hold</mode>
                     </slot>
                     <slot>
                         <code>0x1000023</code>

--- a/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
+++ b/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
@@ -305,8 +305,8 @@
             <stick index="2">
                 <diagonalRange>90</diagonalRange>
                 <stickbutton index="1">
-                    <mousespeedx>150</mousespeedx>
-                    <mousespeedy>150</mousespeedy>
+                    <mousespeedx>25</mousespeedx>
+                    <mousespeedy>25</mousespeedy>
                     <slots>
                         <slot>
                             <code>1</code>
@@ -315,12 +315,12 @@
                     </slots>
                 </stickbutton>
                 <stickbutton index="2">
-                    <mousespeedx>150</mousespeedx>
-                    <mousespeedy>150</mousespeedy>
+                    <mousespeedx>25</mousespeedx>
+                    <mousespeedy>25</mousespeedy>
                 </stickbutton>
                 <stickbutton index="3">
-                    <mousespeedx>150</mousespeedx>
-                    <mousespeedy>150</mousespeedy>
+                    <mousespeedx>25</mousespeedx>
+                    <mousespeedy>25</mousespeedy>
                     <slots>
                         <slot>
                             <code>4</code>
@@ -329,12 +329,12 @@
                     </slots>
                 </stickbutton>
                 <stickbutton index="4">
-                    <mousespeedx>150</mousespeedx>
-                    <mousespeedy>150</mousespeedy>
+                    <mousespeedx>25</mousespeedx>
+                    <mousespeedy>25</mousespeedy>
                 </stickbutton>
                 <stickbutton index="5">
-                    <mousespeedx>150</mousespeedx>
-                    <mousespeedy>150</mousespeedy>
+                    <mousespeedx>25</mousespeedx>
+                    <mousespeedy>25</mousespeedy>
                     <slots>
                         <slot>
                             <code>2</code>
@@ -343,12 +343,12 @@
                     </slots>
                 </stickbutton>
                 <stickbutton index="6">
-                    <mousespeedx>150</mousespeedx>
-                    <mousespeedy>150</mousespeedy>
+                    <mousespeedx>25</mousespeedx>
+                    <mousespeedy>25</mousespeedy>
                 </stickbutton>
                 <stickbutton index="7">
-                    <mousespeedx>150</mousespeedx>
-                    <mousespeedy>150</mousespeedy>
+                    <mousespeedx>25</mousespeedx>
+                    <mousespeedy>25</mousespeedy>
                     <slots>
                         <slot>
                             <code>3</code>
@@ -357,8 +357,8 @@
                     </slots>
                 </stickbutton>
                 <stickbutton index="8">
-                    <mousespeedx>150</mousespeedx>
-                    <mousespeedy>150</mousespeedy>
+                    <mousespeedx>25</mousespeedx>
+                    <mousespeedy>25</mousespeedy>
                 </stickbutton>
             </stick>
             <dpad index="1">

--- a/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
+++ b/applications/The Witcher/sdlgamecontroller/witcher1-antimicro.gamecontroller.xml
@@ -501,6 +501,22 @@
                 <actionname>Camera</actionname>
                 <slots>
                     <slot>
+                        <code>0x47</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>1</code>
+                        <mode>cycle</mode>
+                    </slot>
+                    <slot>
+                        <code>0x46</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                    <slot>
+                        <code>1</code>
+                        <mode>cycle</mode>
+                    </slot>
+                    <slot>
                         <code>0x1000030</code>
                         <mode>keyboard</mode>
                     </slot>
@@ -518,22 +534,6 @@
                     </slot>
                     <slot>
                         <code>0x1000032</code>
-                        <mode>keyboard</mode>
-                    </slot>
-                    <slot>
-                        <code>1</code>
-                        <mode>cycle</mode>
-                    </slot>
-                    <slot>
-                        <code>0x47</code>
-                        <mode>keyboard</mode>
-                    </slot>
-                    <slot>
-                        <code>1</code>
-                        <mode>cycle</mode>
-                    </slot>
-                    <slot>
-                        <code>0x46</code>
                         <mode>keyboard</mode>
                     </slot>
                 </slots>


### PR DESCRIPTION
Completely redone profile for "The Witcher" (including "Enhanced Edition" and "The Rise of the White Wolf" mod), the old one was missing several (for me) essential keybindings.

---

# General notes

* key-binds used were the default US key-binds 
  * **Note:** I used [this table](http://witcher.wikia.com/wiki/The_Witcher_controls), which should work for everyone, but I may have missed a key or two (I use a German keyboard)
* action names for every binding for easy lookup on a second screen or mobile (via screenshot)
  * exceptions are the trigger buttons and analogue sticks, since their actions currently do not allow to be named (see AntiMicro/antimicro#41)
* Profile tested with an Xbox One Controller (Original, not the S) through ~~Chapter I and most of Chapter II~~ the whole game, adjusting it as necessary
  * it has been tested with OTS mode only, since I find the isometric mode to be just awful to play with
* ~~Mouse-speed setting in AntiMicro does not seem to affect camera rotation in the game, however it does affect cursor movement in menus~~
  * ~~use the Camera Sensitivity Setting in the Game options instead~~

# Key-binds

## Set 1 (default)
![image](https://cloud.githubusercontent.com/assets/556162/25307868/69f66f4e-27a9-11e7-8c2a-fde4049dad9c.png)

* everything you need for interaction and most fighting
* _DPad:_ also serves as a selector for dialogue options 1-4 (which is enough for most dialogues)
* _A_, _Right Shoulder Button_, _Left Stick Click_, and _Right Stick Click:_ also usable as dialogue options 5-8 (though I haven't encountered anything more then 5 yet).
* _Left Trigger:_ `Right Mouse Button` (Sign Casting) & _Right Trigger:_ `Left Mouse Button` (Sword Attack)
  * it seems confusing, but most other games these days use the _Right Trigger_ for primary and _Left Trigger_ for secondary shooting/attacking, so it turns out this plays more intuitive
* _Guide Button:_ it may or may not activate steam overlay alongside pausing the game, but this is an issue with AntiMicro, or rather the SDL Library and/or Windows' drivers (also see AntiMicro/antimicro#90)
  * if this is an issue for you, remove the binding and/or rebind it to _Left Shoulder Button_ + _Y_, more on that below
  * personally, I had to disable Steam's overlay anyway since it was crashing my game

## Set 2 (while holding _Left Shoulder Button_)
![image](https://cloud.githubusercontent.com/assets/556162/25307877/72c2700a-27a9-11e7-8891-9efe05ba7199.png)
* everything non-essential and/or non-time-critical
* combat styles can be changed while a swing is performed
  * alternatively you can press the respective weapon button to switch styles
* _A_ and _B:_ those were extremely valuable to me since auto-saving in this game is cumbersome at best, sometimes it won't auto-save for hours
* _Y:_ "Extra Weapon 1" - this is your additional heavy weapon, which you probably won't end up using anyway (they don't scale with damage bonuses from witcher fighting styles, there is just no point in using them), so here are a few alternatives:
  * `Spacebar`: Pause the game (this is bound to Guide in the default page)
  * `Alt`: Showing and Hiding visible object names for more immersion, freeing up _Right Stick Click_ in the process
  * `G`: swap camera sides in OTS Mode. I personally haven't needed this yet, but I can see how it could be useful
* _X:_ "Extra Weapon 3" (weird choice of counting since "Extra Weapon 2" is only received towards the end) - This is the small weapon slot for torches, daggers and small axes. You probably won't use them either, but at least the torch has its uses every now and then.
* _Guide:_ in a perfect world this would be the one triggering Steam Overlay while in default mode only pause is activated, but we all know the world is cruel
* _Right analog stick:_ Mouse movement is slowed down in this mode. I found it useful in certain menus when you just need a tiny bit more precision. Does not affect camera rotation (see General note above)
* _Right Shoulder Button:_ Cycles through various camera modes as follows:
  1. "Switch OTS Camera Side"
  2. "Flip OTS Camera"
  3. "High Isometric Camera"
  4. "Low Isometric Camera"
  5. "OTS Camera"
* _Left Trigger_ and _Right Trigger_ speaking of camera, this changes zoom level in OTS mode, rarely used in my experience
* _Left Stick Click:_ `Esc` for normal button press,  `Alt` + `F4` after 0.5sec to Quit (the game asks for confirmation).

# License and crediting
I was never a big fan of the GPL, but I don't mind. This is my personal profile anyway, if anyone can have fun with it too so be it :) credit could either be mihawk90 per my account name, or Tarulia per my usual online alter ego (preferred)