### PR TITLE
Guitar hero 3

### DIFF
--- a/applications/Guitar Hero 3/ba124b07000000000000504944564944/Guitar Hero 3.gamecontroller.amgp
+++ b/applications/Guitar Hero 3/ba124b07000000000000504944564944/Guitar Hero 3.gamecontroller.amgp
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gamecontroller configversion="19" appversion="2.23">
+    <!--The SDL name for a joystick is included for informational purposes only.-->
+    <sdlname>Guitar Hero </sdlname>
+    <!--The GUID for a joystick is included for informational purposes only.-->
+    <guid>ba124b07000000000000504944564944</guid>
+    <names/>
+    <sets>
+        <set index="1">
+            <stick index="1">
+                <stickbutton index="5">
+                    <slots>
+                        <slot>
+                            <code>2</code>
+                            <mode>mousebutton</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+            </stick>
+            <stick index="2">
+                <stickbutton index="5">
+                    <slots>
+                        <slot>
+                            <code>1</code>
+                            <mode>mousebutton</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="1">
+                    <slots>
+                        <slot>
+                            <code>3</code>
+                            <mode>mousebutton</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+                <stickbutton index="3">
+                    <slots>
+                        <slot>
+                            <code>0x11000023</code>
+                            <mode>keyboard</mode>
+                        </slot>
+                    </slots>
+                </stickbutton>
+            </stick>
+            <dpad index="1">
+                <dpadbutton index="4">
+                    <slots>
+                        <slot>
+                            <code>1</code>
+                            <mode>mousebutton</mode>
+                        </slot>
+                    </slots>
+                </dpadbutton>
+                <dpadbutton index="1">
+                    <slots>
+                        <slot>
+                            <code>3</code>
+                            <mode>mousebutton</mode>
+                        </slot>
+                    </slots>
+                </dpadbutton>
+            </dpad>
+            <trigger index="1">
+                <deadZone>6000</deadZone>
+                <throttle>positivehalf</throttle>
+            </trigger>
+            <trigger index="2">
+                <deadZone>6000</deadZone>
+                <throttle>positivehalf</throttle>
+            </trigger>
+            <button index="1">
+                <slots>
+                    <slot>
+                        <code>0x56</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="2">
+                <slots>
+                    <slot>
+                        <code>0x43</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="3">
+                <slots>
+                    <slot>
+                        <code>0x58</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="4">
+                <slots>
+                    <slot>
+                        <code>0x5a</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="5">
+                <slots>
+                    <slot>
+                        <code>2</code>
+                        <mode>mousebutton</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="7">
+                <slots>
+                    <slot>
+                        <code>0x1000003</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+            <button index="10">
+                <slots>
+                    <slot>
+                        <code>0x1000020</code>
+                        <mode>keyboard</mode>
+                    </slot>
+                </slots>
+            </button>
+        </set>
+    </sets>
+</gamecontroller>

--- a/applications/Guitar Hero 3/ba124b07000000000000504944564944/README.txt
+++ b/applications/Guitar Hero 3/ba124b07000000000000504944564944/README.txt
@@ -1,0 +1,3 @@
+This configuration was made for Guitar Hero Live controller.
+The DPad (placed where the is the sync button) could be used as Strum if your strum does not work with buttons holded.
+The strum issue could be related to non-xbox 360 adapters.


### PR DESCRIPTION
Added Guitar Hero 3 keyboard mapping with Guitar Hero Live.
It should require a specific mapping since Guitar Hero Live is not an XInput device, although I don't know where should I paste my game controller mapping string.